### PR TITLE
Fix improper text wrapping for Shorts

### DIFF
--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -426,6 +426,8 @@ class YouTube:
             color="#FFFF00",
             stroke_color="black",
             stroke_width=5,
+            size=(1080, 0),
+            method="caption",
         )
 
         print(colored("[+] Combining images...", "blue"))


### PR DESCRIPTION
Corrects text wrapping in YouTube Shorts by defining the size and applying the subtitles to the video using a specific method.