### PR TITLE
Fix Local variable 'twitter_uuid' might be referenced before assignment

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -319,7 +319,7 @@ def main():
                 # Find the account
                 account = None
                 for acc in get_accounts("twitter"):
-                    if acc["id"] == twitter_uuid:
+                    if acc["id"] == selected_product["twitter_uuid"]:
                         account = acc
 
                 afm = AffiliateMarketing(selected_product["affiliate_link"], account["firefox_profile"], account["id"], account["nickname"], account["topic"])


### PR DESCRIPTION
Fix Local variable 'twitter_uuid' might be referenced before assignment.

Which can not match twitter_uuid between twitter config and AFM config selection.

Relative Error:
File "MoneyPrinterV2/src/main.py", line 294, in main
afm = AffiliateMarketing(affiliate_link, account["firefox_profile"], account["id"], account["nickname"], account["topic"])
TypeError: 'NoneType' object is not subscriptable