### PR TITLE
Fix subtitles burned before SRT equalization

### DIFF
--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -474,10 +474,11 @@ class YouTube:
         
         subtitles_path = self.generate_subtitles(self.tts_path)
 
+        # Equalize srt file
+        equalize_subtitles(subtitles_path, 10)
+        
         # Burn the subtitles into the video
         subtitles = SubtitlesClip(subtitles_path, generator)
-
-        equalize_subtitles(subtitles_path, 10)
 
         subtitles.set_pos(("center", "center"))
         random_song_clip = AudioFileClip(random_song).set_fps(44100)


### PR DESCRIPTION
This pull request fixes an issue where subtitles were burned into the video before SRT equalization. This leads to inconsistencies in the final output. The proposed changes ensure that SRT equalization occurs before the burning of subtitles, resulting in more visible subtitles. 

Related to issue: https://github.com/FujiwaraChoki/MoneyPrinterV2/issues/42