### PR TITLE
docs: Update README with cd MoneyPrinterV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Please install [Microsoft Visual C++ build tools](https://visualstudio.microsoft
 ```bash
 git clone https://github.com/FujiwaraChoki/MoneyPrinterV2.git
 
+cd MoneyPrinterV2
 # Copy Example Configuration and fill out values in config.json
 cp config.example.json config.json
 


### PR DESCRIPTION
This pull request updates the README file by adding the command `cd MoneyPrinterV2` after the `git clone` command. This change lets you just copy paste that part directly into the terminal. Super small change.

The updated section in the README would look like this:

```bash
git clone https://github.com/FujiwaraChoki/MoneyPrinterV2.git
cd MoneyPrinterV2
# Copy Example Configuration and fill out values in config.json
cp config.example.json config.json