### PR TITLE
Handle WebDriver session more robustly

### DIFF
--- a/src/classes/AFM.py
+++ b/src/classes/AFM.py
@@ -137,6 +137,9 @@ class AffiliateMarketing:
             where (str): The platform where the pitch will be shared.
         """
         if where == "twitter":
+            # Kill our scraping session
+            self.quit()
+
             # Initialize the Twitter class
             twitter: Twitter = Twitter(self.account_uuid, self.account_nickname, self._fp_profile_path, self.topic)
 
@@ -149,3 +152,5 @@ class AffiliateMarketing:
         """
         # Quit the browser
         self.browser.quit()
+        # Stop the service
+        self.service.stop()

--- a/src/classes/AFM.py
+++ b/src/classes/AFM.py
@@ -39,8 +39,9 @@ class AffiliateMarketing:
             self.options.add_argument("--headless")
 
         # Set the profile path
-        self.options.add_argument("-profile")
-        self.options.add_argument(fp_profile_path)
+        profile = webdriver.FirefoxProfile(fp_profile_path)
+        self.options.profile = profile
+
         
         # Set the service
         self.service: Service = Service(GeckoDriverManager().install())

--- a/src/classes/Twitter.py
+++ b/src/classes/Twitter.py
@@ -49,8 +49,9 @@ class Twitter:
             self.options.add_argument("--headless")
 
         # Set the profile path
-        self.options.add_argument("-profile")
-        self.options.add_argument(fp_profile_path)
+        profile = webdriver.FirefoxProfile(fp_profile_path)
+        self.options.profile = profile
+
 
         # Set the service
         self.service: Service = Service(GeckoDriverManager().install())


### PR DESCRIPTION
Currently, there is an issue where the Twitter selenium service cannot init because the AFM selenium service is still running. This PR fixes that, and uses the `webdriver.FirefoxProfile` method of setting the profile instead of adding a `-profile` argument to the CLI for consistency, because it is used elsewhere in the codebase.