### PR TITLE
Fix ModuleNotFoundError: pin moviepy==1.0.3 and numpy==1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ webdriver_manager
 selenium_firefox
 selenium
 g4f
-moviepy
+moviepy==1.0.3
+numpy==1.26.4
 Pillow==9.5.0
 yagmail
 assemblyai


### PR DESCRIPTION
## Summary

- **Pins `moviepy==1.0.3`** in `requirements.txt` to fix `ModuleNotFoundError: No module named 'moviepy.video.fx.crop'`
- **Pins `numpy==1.26.4`** to ensure compatibility with moviepy 1.x (numpy 2.x introduced breaking changes)

## Problem

The codebase uses moviepy 1.x APIs (`moviepy.editor`, `moviepy.video.fx.all`, `moviepy.video.tools.subtitles`, `moviepy.config`), but without a version pin, `pip install moviepy` now installs moviepy 2.x which reorganized its module structure, breaking these imports.

## Root Cause

In moviepy 2.x, modules like `moviepy.video.fx.all` and `moviepy.editor` were removed or restructured. Since the codebase relies on the 1.x API throughout `src/classes/YouTube.py`, pinning to `moviepy==1.0.3` is the correct fix.

Fixes #117

## Test plan

- [ ] Fresh `pip install -r requirements.txt` in a clean virtual environment
- [ ] Verify `from moviepy.video.fx.all import crop` imports successfully
- [ ] Verify `from moviepy.editor import *` imports successfully
- [ ] Run `python src/main.py` without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)