### PR TITLE
Fix subprocess.run() crash in CRON job setup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -184,19 +184,9 @@ def main():
                         user_input = int(question("Select an Option: "))
 
                         cron_script_path = os.path.join(ROOT_DIR, "src", "cron.py")
-                        command = f"python {cron_script_path} youtube {selected_account['id']}"
+                        command = ["python", cron_script_path, "youtube", selected_account['id']]
 
                         def job():
-                            """Executes a shell command using subprocess.run.
-
-    This function runs a specified shell command using the subprocess module.
-    The command to be executed should be defined in the 'command' variable.
-
-    Args:
-        None
-
-    Returns:
-        None"""
                             subprocess.run(command)
 
                         if user_input == 1:
@@ -302,19 +292,9 @@ def main():
                         user_input = int(question("Select an Option: "))
 
                         cron_script_path = os.path.join(ROOT_DIR, "src", "cron.py")
-                        command = f"python {cron_script_path} twitter {selected_account['id']}"
+                        command = ["python", cron_script_path, "twitter", selected_account['id']]
 
                         def job():
-                            """Executes a shell command using subprocess.run.
-
-    This function runs a specified shell command using the subprocess module.
-    The command to be executed should be defined in the 'command' variable.
-
-    Args:
-        None
-
-    Returns:
-        None"""
                             subprocess.run(command)
 
                         if user_input == 1:


### PR DESCRIPTION
## Summary
- `subprocess.run()` in both YouTube and Twitter CRON job functions was called with a **string** command (e.g. `"python /path/cron.py youtube uuid"`), but without `shell=True`. This causes Python to treat the entire string as a single executable name, resulting in a `FileNotFoundError` whenever a user tries to set up scheduled uploads or posts.
- Changed command construction from an f-string to a **list** (`["python", path, "youtube", id]`), which `subprocess.run()` handles correctly and is also safer against shell injection.

## Test plan
- [x] Set up a YouTube CRON job (option 3 in YouTube menu) and verify no crash on job creation
- [x] Set up a Twitter CRON job (option 3 in Twitter menu) and verify no crash on job creation
- [x] Verify scheduled job executes `cron.py` correctly when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)