### PR TITLE
Fix generate_script() ignoring retry result

### DIFF
--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -190,7 +190,7 @@ class YouTube:
         if len(completion) > 5000:
             if get_verbose():
                 warning("Generated Script is too long. Retrying...")
-            self.generate_script()
+            return self.generate_script()
         
         self.script = completion
     


### PR DESCRIPTION
## Summary
- `generate_script()` calls itself recursively when the generated script exceeds 5000 characters, but the return value was discarded — the original too-long `completion` always overwrote `self.script` and was returned regardless.
- Added the missing `return` keyword to match the identical retry pattern already used in `generate_metadata()` (line 211) and `generate_prompts()` (line 295).

## Test plan
- [x] Generate a video where the LLM produces a script >5000 chars on the first attempt — verify the retry produces a shorter script that is actually used
- [x] Verify normal script generation (<5000 chars) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)