### PR TITLE
Fix songs download fallback and audio selection

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -80,8 +80,14 @@ def fetch_songs() -> None:
             if get_verbose():
                 info(f" => Created directory: {files_dir}")
         else:
-            # Skip if songs are already downloaded
-            return
+            existing_audio_files = [
+                name
+                for name in os.listdir(files_dir)
+                if os.path.isfile(os.path.join(files_dir, name))
+                and name.lower().endswith((".mp3", ".wav", ".m4a", ".aac", ".ogg"))
+            ]
+            if len(existing_audio_files) > 0:
+                return
 
         configured_url = get_zip_url().strip()
         download_urls = [configured_url] if configured_url else []


### PR DESCRIPTION
## Summary
- add fallback download URL handling for song archives instead of relying on a single endpoint
- validate each archive download before extraction and provide clear warnings per failed URL
- improve random track selection to only consider audio files and fail clearly when none are available
- preserve cleanup behavior for temporary archives after successful extraction

## Why this change
Song zip URLs regularly expire or return invalid payloads, causing startup failures and corrupted media state. This update makes song fetching resilient and ensures video generation only picks valid audio files.

## Related issues
- #118
- #124