### PR TITLE
Fix Twitter posting flow for X compose UI

### DIFF
--- a/src/classes/Twitter.py
+++ b/src/classes/Twitter.py
@@ -87,11 +87,11 @@ class Twitter:
 
         bot.get("https://x.com/compose/post")
 
-        post_content: str = self.generate_post()
+        post_content: str = text if text is not None else self.generate_post()
         now: datetime = datetime.now()
 
         print(colored(" => Posting to Twitter:", "blue"), post_content[:30] + "...")
-        body = post_content if text is None else text
+        body = post_content
 
         text_box = None
         text_box_selectors = [
@@ -137,9 +137,7 @@ class Twitter:
         time.sleep(2)
 
         # Add the post to the cache
-        self.add_post(
-            {"content": post_content, "date": now.strftime("%m/%d/%Y, %H:%M:%S")}
-        )
+        self.add_post({"content": body, "date": now.strftime("%m/%d/%Y, %H:%M:%S")})
 
         success("Posted to Twitter successfully!")
 


### PR DESCRIPTION
## Summary
- make the Twitter bot post from `https://x.com/compose/post` instead of relying on stale timeline selectors
- add robust textarea and post-button selector fallbacks with explicit waits to tolerate X UI variations
- validate Firefox profile directories early and prevent recursive over-generation when post text exceeds the char limit
- correct twitter cache bootstrap to use `accounts` shape and always return a list from `get_posts`

## Why this change
Issue reports show repeated failures where the bot cannot find the new tweet button/text box after X UI updates, then crashes or loops. This update makes the posting path resilient to current compose patterns and improves error messages so setup mistakes are actionable.

## Related issues
- #100
- #111