### PR TITLE
Fix critical supply chain poisoning in default song archive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ selenium_firefox
 selenium
 ollama
 moviepy
-Pillow==9.5.0
+Pillow>=10.0.0
 yagmail
 assemblyai
 faster-whisper

--- a/src/classes/Outreach.py
+++ b/src/classes/Outreach.py
@@ -55,7 +55,7 @@ class Outreach:
         """
         # Check if go is installed
         try:
-            subprocess.call("go version", shell=True)
+            subprocess.call(["go", "version"])
             return True
         except Exception as e:
             return False
@@ -76,7 +76,11 @@ class Outreach:
 
         r = requests.get(zip_link)
         z = zipfile.ZipFile(io.BytesIO(r.content))
-        z.extractall()
+        for member in z.namelist():
+            if ".." in member or member.startswith("/"):
+                warning(f"Skipping suspicious path in archive: {member}")
+                continue
+            z.extract(member)
 
     def build_scraper(self) -> None:
         """

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,9 +7,7 @@ import platform
 from status import *
 from config import *
 
-DEFAULT_SONG_ARCHIVE_URLS = [
-    "https://filebin.net/bb9ewdtckolsf3sg/drive-download-20240209T180019Z-001.zip"
-]
+DEFAULT_SONG_ARCHIVE_URLS = []
 
 
 def close_running_selenium_instances() -> None:
@@ -104,8 +102,17 @@ def fetch_songs() -> None:
                 with open(archive_path, "wb") as file:
                     file.write(response.content)
 
-                with zipfile.ZipFile(archive_path, "r") as file:
-                    file.extractall(files_dir)
+                SAFE_EXTENSIONS = (".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac")
+                with zipfile.ZipFile(archive_path, "r") as zf:
+                    for member in zf.namelist():
+                        basename = os.path.basename(member)
+                        if not basename or not basename.lower().endswith(SAFE_EXTENSIONS):
+                            warning(f"Skipping non-audio file in archive: {member}")
+                            continue
+                        if ".." in member or member.startswith("/"):
+                            warning(f"Skipping suspicious path in archive: {member}")
+                            continue
+                        zf.extract(member, files_dir)
 
                 downloaded = True
                 break


### PR DESCRIPTION
## Summary

- **Remove malicious `filebin.net` URL** from `DEFAULT_SONG_ARCHIVE_URLS` in `src/utils.py` — the hosted zip contains credential-stealing malware (`.bashrc`, `.profile`, `.zshrc`) that exfiltrates API keys, browser cookies, SSH keys, and other sensitive data to a C2 server
- **Harden zip extraction** in `fetch_songs()` to only allow audio file extensions (`.mp3`, `.wav`, `.m4a`, `.aac`, `.ogg`, `.flac`) and reject path traversal attempts
- **Harden zip extraction** in `Outreach.unzip_file()` with path traversal protection
- **Remove `shell=True`** from subprocess call in `Outreach.check_go()`
- **Update Pillow** version constraint for Python 3.12 compatibility

## Vulnerability Details

The default song archive at `https://filebin.net/bb9ewdtckolsf3sg/drive-download-20240209T180019Z-001.zip` contains a trojanized payload that:

1. Connects to C2 server at `https://pseudoidentical-foreseeingly-kurtis.ngrok-free.dev`
2. Extracts all credentials from `config.json` (Gemini API key, AssemblyAI key, SMTP credentials)
3. Steals Firefox cookies (`cookies.sqlite`) and saved logins (`logins.json`)
4. Scans for SSH keys, AWS credentials, GCP/Docker/Kubernetes configs
5. Exfiltrates all data via HTTP POST to the C2 server
6. Poisons `config.json` to redirect API calls through the attacker's proxy

This executes automatically on first run when the `Songs/` directory is empty.

## Files Changed

| File | Change |
|---|---|
| `src/utils.py` | Removed malicious URL, hardened zip extraction (audio-only + path traversal protection) |
| `src/classes/Outreach.py` | Hardened zip extraction, removed `shell=True` |
| `requirements.txt` | Updated `Pillow==9.5.0` to `Pillow>=10.0.0` for Python 3.12 |
