### PR TITLE
fix: remove selenium_firefox dependency for Selenium 4 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ kittentts @ https://github.com/KittenML/KittenTTS/releases/download/0.8.1/kitten
 soundfile
 prettytable
 webdriver_manager
-selenium_firefox
 selenium
 ollama
 moviepy

--- a/src/classes/AFM.py
+++ b/src/classes/AFM.py
@@ -7,7 +7,6 @@ from config import *
 from constants import *
 from llm_provider import generate_text
 from .Twitter import Twitter
-from selenium_firefox import *
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.service import Service

--- a/src/classes/Twitter.py
+++ b/src/classes/Twitter.py
@@ -11,7 +11,6 @@ from llm_provider import generate_text
 from typing import List, Optional
 from datetime import datetime
 from termcolor import colored
-from selenium_firefox import *
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.service import Service

--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -17,7 +17,6 @@ from constants import *
 from typing import List
 from moviepy.editor import *
 from termcolor import colored
-from selenium_firefox import *
 from selenium import webdriver
 from moviepy.video.fx.all import crop
 from moviepy.config import change_settings


### PR DESCRIPTION
## Summary
- Fixes #137 — `ModuleNotFoundError: No module named 'selenium.webdriver.firefox.firefox_binary'`
- The `selenium_firefox` package internally imports `selenium.webdriver.firefox.firefox_binary`, which was removed in Selenium 4.x
- The codebase already uses the modern `Options`/`Service` API directly, so `selenium_firefox` was redundant
- Removed `from selenium_firefox import *` from `AFM.py`, `Twitter.py`, and `YouTube.py`
- Removed `selenium_firefox` from `requirements.txt`
- Also addresses related issues #90, #84, #111 which stem from the same root cause

## Changes
- `src/classes/AFM.py` — removed unused `selenium_firefox` import
- `src/classes/Twitter.py` — removed unused `selenium_firefox` import
- `src/classes/YouTube.py` — removed unused `selenium_firefox` import
- `requirements.txt` — removed `selenium_firefox` dependency

## Test plan
- [x] Verified all three files already use `Options` and `Service` from `selenium.webdriver.firefox` directly
- [x] Confirmed `selenium_firefox` provided no symbols actually referenced in the codebase
- [x] Imports resolve correctly with Selenium 4.x after removal