### PR TITLE
Specify Affero License is GNU.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for details on our code of 
 
 ## License
 
-MoneyPrinterV2 is licensed under `Affero General Public License v3.0`. See [LICENSE](LICENSE) for more information.
+MoneyPrinterV2 is licensed under `GNU Affero General Public License v3.0`. See [LICENSE](LICENSE) for more information.
 
 ## Acknowledgments
 


### PR DESCRIPTION
It may be more clear and familiar to users to specifically specify that this is a GNU license.