### PR TITLE
Fix bare except clause in YouTube upload_video()

### DIFF
--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -848,7 +848,8 @@ class YouTube:
             driver.quit()
 
             return True
-        except:
+        except Exception as e:
+            error(f"Failed to upload video: {e}")
             self.browser.quit()
             return False
 


### PR DESCRIPTION
Fixes #182

## Changes
- Replace bare `except:` with `except Exception as e:`
- Log the error before returning False