### PR TITLE
Fix unclosed file handle in outreach email body reading

### DIFF
--- a/src/classes/Outreach.py
+++ b/src/classes/Outreach.py
@@ -274,11 +274,8 @@ class Outreach:
                         subject = message_subject.replace(
                             "{{COMPANY_NAME}}", company_name
                         )
-                        body = (
-                            open(message_body, "r")
-                            .read()
-                            .replace("{{COMPANY_NAME}}", company_name)
-                        )
+                        with open(message_body, "r") as f:
+                            body = f.read().replace("{{COMPANY_NAME}}", company_name)
 
                         info(f" => Sending email to {receiver_email}...")
 


### PR DESCRIPTION
Fixes #184 

## Changes
- Replace bare `open().read()` with `with open()` context manager
- Ensures file handle is properly closed after reading
