### PR TITLE
Add return type annotation to main function

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ from classes.Outreach import Outreach
 from classes.AFM import AffiliateMarketing
 from llm_provider import list_models, select_model, get_active_model
 
-def main():
+def main() -> None:
     """Main entry point for the application, providing a menu-driven interface
     to manage YouTube, Twitter bots, Affiliate Marketing, and Outreach tasks.
 


### PR DESCRIPTION
Add type hint (-> None) to the main() function signature to improve static analysis and clarify that main does not return a value.