### PR TITLE
Add structured logging, config validation, thread-safe cache, and Selenium improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 MoneyPrinterV2 (MPV2) is a Python 3.12 CLI tool that automates four online workflows:
-1. **YouTube Shorts** — generate video (LLM script → TTS → images → MoviePy composite) and upload via Selenium
-2. **Twitter/X Bot** — generate and post tweets via Selenium
-3. **Affiliate Marketing** — scrape Amazon product info, generate pitch, share on Twitter
-4. **Local Business Outreach** — scrape Google Maps (Go binary), extract emails, send cold outreach via SMTP
+1. **YouTube Shorts** - generate video (LLM script → TTS → images → MoviePy composite) and upload via Selenium
+2. **Twitter/X Bot** - generate and post tweets via Selenium
+3. **Affiliate Marketing** - scrape Amazon product info, generate pitch, share on Twitter
+4. **Local Business Outreach** - scrape Google Maps (Go binary), extract emails, send cold outreach via SMTP
 
 There is no web UI, no REST API, no test suite, no CI, and no linting config.
 
@@ -35,8 +35,8 @@ The app **must** be run from the project root. `python src/main.py` adds `src/` 
 ## Architecture
 
 ### Entry Points
-- `src/main.py` — interactive menu loop (primary)
-- `src/cron.py` — headless runner invoked by the scheduler as a subprocess: `python src/cron.py <platform> <account_uuid>`
+- `src/main.py` - interactive menu loop (primary)
+- `src/cron.py` - headless runner invoked by the scheduler as a subprocess: `python src/cron.py <platform> <account_uuid>`
 
 ### Provider Pattern
 Two service categories use a string-based dispatch pattern configured in `config.json`:
@@ -44,24 +44,24 @@ Two service categories use a string-based dispatch pattern configured in `config
 | Category | Config key | Options |
 |---|---|---|
 | LLM | `ollama_model` | Ollama (via `ollama` Python SDK). If empty, user picks from available models at startup. |
-| Image gen | — | `nanobanana2` (Gemini image API) |
+| Image gen | - | `nanobanana2` (Gemini image API) |
 | STT | `stt_provider` | `local_whisper`, `third_party_assemblyai` |
 
 LLM always uses the local Ollama server. Image generation always uses Nano Banana 2.
 
 ### Key Modules
-- **`src/llm_provider.py`** — unified `generate_text(prompt)` function using the Ollama Python SDK
-- **`src/config.py`** — 30+ getter functions, each re-reads `config.json` on every call (no caching). `ROOT_DIR` = project root, computed as `os.path.dirname(sys.path[0])`
-- **`src/cache.py`** — JSON file persistence in `.mp/` directory (accounts, videos, posts, products)
-- **`src/constants.py`** — menu strings, Selenium selectors (YouTube Studio, X.com, Amazon)
-- **`src/classes/YouTube.py`** — most complex class; full pipeline: topic → script → metadata → image prompts → images → TTS → subtitles → MoviePy combine → Selenium upload
-- **`src/classes/Twitter.py`** — Selenium automation against x.com
-- **`src/classes/AFM.py`** — Amazon scraping + LLM pitch generation
-- **`src/classes/Outreach.py`** — Google Maps scraper (requires Go) + email sending via yagmail
-- **`src/classes/Tts.py`** — KittenTTS wrapper
+- **`src/llm_provider.py`** - unified `generate_text(prompt)` function using the Ollama Python SDK
+- **`src/config.py`** - 30+ getter functions, each re-reads `config.json` on every call (no caching). `ROOT_DIR` = project root, computed as `os.path.dirname(sys.path[0])`
+- **`src/cache.py`** - JSON file persistence in `.mp/` directory (accounts, videos, posts, products)
+- **`src/constants.py`** - menu strings, Selenium selectors (YouTube Studio, X.com, Amazon)
+- **`src/classes/YouTube.py`** - most complex class; full pipeline: topic → script → metadata → image prompts → images → TTS → subtitles → MoviePy combine → Selenium upload
+- **`src/classes/Twitter.py`** - Selenium automation against x.com
+- **`src/classes/AFM.py`** - Amazon scraping + LLM pitch generation
+- **`src/classes/Outreach.py`** - Google Maps scraper (requires Go) + email sending via yagmail
+- **`src/classes/Tts.py`** - KittenTTS wrapper
 
 ### Data Storage
-All persistent state lives in `.mp/` at the project root as JSON files (`youtube.json`, `twitter.json`, `afm.json`). This directory also serves as scratch space for temporary WAV, PNG, SRT, and MP4 files — non-JSON files are cleaned on each run by `rem_temp_files()`.
+All persistent state lives in `.mp/` at the project root as JSON files (`youtube.json`, `twitter.json`, `afm.json`). This directory also serves as scratch space for temporary WAV, PNG, SRT, and MP4 files - non-JSON files are cleaned on each run by `rem_temp_files()`.
 
 ### Browser Automation
 Selenium uses pre-authenticated Firefox profiles (never handles login). The profile path is stored per-account in the cache JSON and also in `config.json` as a default.
@@ -72,11 +72,11 @@ Uses Python's `schedule` library (in-process, not OS cron). The scheduled job sp
 ## Configuration
 
 All config lives in `config.json` at the project root. See `config.example.json` for the full template and `docs/Configuration.md` for reference. Key external dependencies to configure:
-- **ImageMagick** — required for MoviePy subtitle rendering (`imagemagick_path`)
-- **Firefox profile** — must be pre-logged-in to target platforms (`firefox_profile`)
-- **Ollama** — for LLM text generation (via `ollama` Python SDK)
-- **Nano Banana 2** — for image generation (Gemini image API)
-- **Go** — only needed for Outreach (Google Maps scraper)
+- **ImageMagick** - required for MoviePy subtitle rendering (`imagemagick_path`)
+- **Firefox profile** - must be pre-logged-in to target platforms (`firefox_profile`)
+- **Ollama** - for LLM text generation (via `ollama` Python SDK)
+- **Nano Banana 2** - for image generation (Gemini image API)
+- **Go** - only needed for Outreach (Google Maps scraper)
 
 ## Contributing
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = src

--- a/src/cache.py
+++ b/src/cache.py
@@ -1,44 +1,31 @@
 import os
 import json
+import fcntl
+import tempfile
 
 from typing import List
 from config import ROOT_DIR
 
-def get_cache_path() -> str:
-    """
-    Gets the path to the cache file.
 
-    Returns:
-        path (str): The path to the cache folder
-    """
+def get_cache_path() -> str:
+    """Gets the path to the cache folder."""
     return os.path.join(ROOT_DIR, '.mp')
 
-def get_afm_cache_path() -> str:
-    """
-    Gets the path to the Affiliate Marketing cache file.
 
-    Returns:
-        path (str): The path to the AFM cache folder
-    """
+def get_afm_cache_path() -> str:
+    """Gets the path to the Affiliate Marketing cache file."""
     return os.path.join(get_cache_path(), 'afm.json')
 
-def get_twitter_cache_path() -> str:
-    """
-    Gets the path to the Twitter cache file.
 
-    Returns:
-        path (str): The path to the Twitter cache folder
-    """
+def get_twitter_cache_path() -> str:
+    """Gets the path to the Twitter cache file."""
     return os.path.join(get_cache_path(), 'twitter.json')
 
-def get_youtube_cache_path() -> str:
-    """
-    Gets the path to the YouTube cache file.
 
-    Returns:
-        path (str): The path to the YouTube cache folder
-    """
+def get_youtube_cache_path() -> str:
+    """Gets the path to the YouTube cache file."""
     return os.path.join(get_cache_path(), 'youtube.json')
+
 
 def get_provider_cache_path(provider: str) -> str:
     """
@@ -60,6 +47,54 @@ def get_provider_cache_path(provider: str) -> str:
 
     raise ValueError(f"Unsupported provider '{provider}'. Expected 'twitter' or 'youtube'.")
 
+
+def _read_json_locked(path: str) -> dict:
+    """
+    Reads a JSON file with a shared (read) lock.
+    Prevents reading while another process is writing.
+    """
+    with open(path, 'r') as f:
+        fcntl.flock(f, fcntl.LOCK_SH)
+        try:
+            return json.load(f)
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def _write_json_atomic(path: str, data: dict) -> None:
+    """
+    Writes a JSON file atomically using a temp file + rename.
+    Uses an exclusive lock to prevent concurrent writes.
+
+    The write goes to a temporary file in the same directory,
+    then atomically replaces the target via os.replace().
+    This prevents partial/corrupt reads from concurrent processes.
+    """
+    dir_name = os.path.dirname(path)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                json.dump(data, f, indent=4)
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+        os.replace(tmp_path, path)
+    except BaseException:
+        # Clean up temp file on any failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _ensure_cache_file(path: str, default_data: dict) -> None:
+    """Creates a cache file with default_data if it does not exist."""
+    if not os.path.exists(path):
+        _write_json_atomic(path, default_data)
+
+
 def get_accounts(provider: str) -> List[dict]:
     """
     Gets the accounts from the cache.
@@ -68,28 +103,21 @@ def get_accounts(provider: str) -> List[dict]:
         provider (str): The provider to get the accounts for
 
     Returns:
-        account (List[dict]): The accounts
+        accounts (List[dict]): The accounts
     """
     cache_path = get_provider_cache_path(provider)
+    _ensure_cache_file(cache_path, {"accounts": []})
 
-    if not os.path.exists(cache_path):
-        # Create the cache file
-        with open(cache_path, 'w') as file:
-            json.dump({
-                "accounts": []
-            }, file, indent=4)
+    parsed = _read_json_locked(cache_path)
 
-    with open(cache_path, 'r') as file:
-        parsed = json.load(file)
+    if parsed is None:
+        return []
 
-        if parsed is None:
-            return []
-        
-        if 'accounts' not in parsed:
-            return []
+    if 'accounts' not in parsed:
+        return []
 
-        # Get accounts dictionary
-        return parsed['accounts']
+    return parsed['accounts']
+
 
 def add_account(provider: str, account: dict) -> None:
     """
@@ -98,23 +126,12 @@ def add_account(provider: str, account: dict) -> None:
     Args:
         provider (str): The provider to add the account to ("twitter" or "youtube")
         account (dict): The account to add
-
-    Returns:
-        None
     """
     cache_path = get_provider_cache_path(provider)
-
-    # Get the current accounts
     accounts = get_accounts(provider)
-
-    # Add the new account
     accounts.append(account)
+    _write_json_atomic(cache_path, {"accounts": accounts})
 
-    # Write the new accounts to the cache
-    with open(cache_path, 'w') as file:
-        json.dump({
-            "accounts": accounts
-        }, file, indent=4)
 
 def remove_account(provider: str, account_id: str) -> None:
     """
@@ -123,71 +140,33 @@ def remove_account(provider: str, account_id: str) -> None:
     Args:
         provider (str): The provider to remove the account from ("twitter" or "youtube")
         account_id (str): The ID of the account to remove
-
-    Returns:
-        None
     """
-    # Get the current accounts
     accounts = get_accounts(provider)
-
-    # Remove the account
     accounts = [account for account in accounts if account['id'] != account_id]
-
-    # Write the new accounts to the cache
     cache_path = get_provider_cache_path(provider)
+    _write_json_atomic(cache_path, {"accounts": accounts})
 
-    with open(cache_path, 'w') as file:
-        json.dump({
-            "accounts": accounts
-        }, file, indent=4)
 
 def get_products() -> List[dict]:
-    """
-    Gets the products from the cache.
+    """Gets the products from the cache."""
+    _ensure_cache_file(get_afm_cache_path(), {"products": []})
 
-    Returns:
-        products (List[dict]): The products
-    """
-    if not os.path.exists(get_afm_cache_path()):
-        # Create the cache file
-        with open(get_afm_cache_path(), 'w') as file:
-            json.dump({
-                "products": []
-            }, file, indent=4)
+    parsed = _read_json_locked(get_afm_cache_path())
+    return parsed.get("products", [])
 
-    with open(get_afm_cache_path(), 'r') as file:
-        parsed = json.load(file)
 
-        # Get the products
-        return parsed["products"]
-    
 def add_product(product: dict) -> None:
     """
     Adds a product to the cache.
 
     Args:
         product (dict): The product to add
-
-    Returns:
-        None
     """
-    # Get the current products
     products = get_products()
-
-    # Add the new product
     products.append(product)
+    _write_json_atomic(get_afm_cache_path(), {"products": products})
 
-    # Write the new products to the cache
-    with open(get_afm_cache_path(), 'w') as file:
-        json.dump({
-            "products": products
-        }, file, indent=4)
-    
+
 def get_results_cache_path() -> str:
-    """
-    Gets the path to the results cache file.
-
-    Returns:
-        path (str): The path to the results cache folder
-    """
+    """Gets the path to the results cache file."""
     return os.path.join(get_cache_path(), 'scraper_results.csv')

--- a/src/classes/Outreach.py
+++ b/src/classes/Outreach.py
@@ -95,7 +95,7 @@ class Outreach:
             else "google-maps-scraper"
         )
         if os.path.exists(binary_name):
-            print(colored("=> Scraper already built. Skipping build.", "blue"))
+            info("=> Scraper already built. Skipping build.")
             return
 
         scraper_dir = self._find_scraper_dir()
@@ -135,14 +135,13 @@ class Outreach:
             scraper_process = subprocess.run(command, timeout=float(timeout))
 
             if scraper_process.returncode == 0:
-                print(colored("=> Scraper finished successfully.", "green"))
+                success("=> Scraper finished successfully.")
             else:
-                print(colored("=> Scraper finished with an error.", "red"))
+                error("=> Scraper finished with an error.")
         except subprocess.TimeoutExpired:
-            print(colored("=> Scraper timed out.", "red"))
+            error("=> Scraper timed out.")
         except Exception as e:
-            print(colored("An error occurred while running the scraper:", "red"))
-            print(str(e))
+            error(f"An error occurred while running the scraper: {e}")
 
     def get_items_from_file(self, file_name: str) -> list:
         """
@@ -186,7 +185,7 @@ class Outreach:
             email = email_addresses[0] if len(email_addresses) > 0 else ""
 
         if email:
-            print(f"=> Setting email {email} for website {website}")
+            info(f"=> Setting email {email} for website {website}")
             with open(output_file, "r", newline="", errors="ignore") as csvfile:
                 csvreader = csv.reader(csvfile)
                 items = list(csvreader)

--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -24,6 +24,8 @@ from moviepy.config import change_settings
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.service import Service
 from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from moviepy.video.tools.subtitles import SubtitlesClip
 from webdriver_manager.firefox import GeckoDriverManager
 from datetime import datetime
@@ -98,6 +100,17 @@ class YouTube:
         self.browser: webdriver.Firefox = webdriver.Firefox(
             service=self.service, options=self.options
         )
+        self.wait: WebDriverWait = WebDriverWait(self.browser, 30)
+
+    def _save_screenshot(self, label: str) -> str:
+        """Saves a browser screenshot for debugging. Returns the path."""
+        screenshot_path = os.path.join(ROOT_DIR, ".mp", f"screenshot_{label}_{uuid4().hex[:8]}.png")
+        try:
+            self.browser.save_screenshot(screenshot_path)
+            warning(f"Screenshot saved to {screenshot_path}")
+        except Exception:
+            pass
+        return screenshot_path
 
     @property
     def niche(self) -> str:
@@ -326,7 +339,7 @@ class YouTube:
         Returns:
             path (str): The path to the generated image.
         """
-        print(f"Generating Image using Nano Banana 2 API: {prompt}")
+        info(f"Generating Image using Nano Banana 2 API: {prompt[:80]}...")
 
         api_key = get_nanobanana2_api_key()
         if not api_key:
@@ -574,7 +587,7 @@ class YouTube:
             method="caption",
         )
 
-        print(colored("[+] Combining images...", "blue"))
+        info("Combining images...")
 
         clips = []
         tot_dur = 0
@@ -700,9 +713,23 @@ class YouTube:
 
         return channel_id
 
+    def _wait_and_find(self, by, value, timeout=30):
+        """Wait for an element to be present and return it."""
+        return WebDriverWait(self.browser, timeout).until(
+            EC.presence_of_element_located((by, value))
+        )
+
+    def _wait_and_click(self, by, value, timeout=30):
+        """Wait for an element to be clickable, then click it."""
+        element = WebDriverWait(self.browser, timeout).until(
+            EC.element_to_be_clickable((by, value))
+        )
+        element.click()
+        return element
+
     def upload_video(self) -> bool:
         """
-        Uploads the video to YouTube.
+        Uploads the video to YouTube using explicit waits for reliability.
 
         Returns:
             success (bool): Whether the upload was successful or not.
@@ -716,25 +743,28 @@ class YouTube:
             # Go to youtube.com/upload
             driver.get("https://www.youtube.com/upload")
 
-            # Set video file
-            FILE_PICKER_TAG = "ytcp-uploads-file-picker"
-            file_picker = driver.find_element(By.TAG_NAME, FILE_PICKER_TAG)
-            INPUT_TAG = "input"
-            file_input = file_picker.find_element(By.TAG_NAME, INPUT_TAG)
+            # Set video file -- wait for the file picker to appear
+            if verbose:
+                info("\t=> Waiting for file picker...")
+            file_picker = self._wait_and_find(By.TAG_NAME, "ytcp-uploads-file-picker")
+            file_input = file_picker.find_element(By.TAG_NAME, "input")
             file_input.send_keys(self.video_path)
 
-            # Wait for upload to finish
-            time.sleep(5)
+            # Wait for the title textbox to appear (signals upload dialog loaded)
+            if verbose:
+                info("\t=> Waiting for upload dialog...")
+            self._wait_and_find(By.ID, YOUTUBE_TEXTBOX_ID, timeout=60)
+
+            # Give YouTube a moment to fully render the form
+            time.sleep(3)
 
             # Set title
             textboxes = driver.find_elements(By.ID, YOUTUBE_TEXTBOX_ID)
-
             title_el = textboxes[0]
             description_el = textboxes[-1]
 
             if verbose:
                 info("\t=> Setting title...")
-
             title_el.click()
             time.sleep(1)
             title_el.clear()
@@ -742,82 +772,57 @@ class YouTube:
 
             if verbose:
                 info("\t=> Setting description...")
-
-            # Set description
-            time.sleep(10)
+            time.sleep(2)
             description_el.click()
             time.sleep(0.5)
             description_el.clear()
             description_el.send_keys(self.metadata["description"])
-
             time.sleep(0.5)
 
             # Set `made for kids` option
             if verbose:
                 info("\t=> Setting `made for kids` option...")
 
-            is_for_kids_checkbox = driver.find_element(
-                By.NAME, YOUTUBE_MADE_FOR_KIDS_NAME
-            )
-            is_not_for_kids_checkbox = driver.find_element(
-                By.NAME, YOUTUBE_NOT_MADE_FOR_KIDS_NAME
-            )
-
             if not get_is_for_kids():
-                is_not_for_kids_checkbox.click()
+                self._wait_and_click(By.NAME, YOUTUBE_NOT_MADE_FOR_KIDS_NAME)
             else:
-                is_for_kids_checkbox.click()
+                self._wait_and_click(By.NAME, YOUTUBE_MADE_FOR_KIDS_NAME)
 
             time.sleep(0.5)
 
-            # Click next
-            if verbose:
-                info("\t=> Clicking next...")
-
-            next_button = driver.find_element(By.ID, YOUTUBE_NEXT_BUTTON_ID)
-            next_button.click()
-
-            # Click next again
-            if verbose:
-                info("\t=> Clicking next again...")
-            next_button = driver.find_element(By.ID, YOUTUBE_NEXT_BUTTON_ID)
-            next_button.click()
-
-            # Wait for 2 seconds
-            time.sleep(2)
-
-            # Click next again
-            if verbose:
-                info("\t=> Clicking next again...")
-            next_button = driver.find_element(By.ID, YOUTUBE_NEXT_BUTTON_ID)
-            next_button.click()
+            # Click through wizard pages (3 "Next" clicks)
+            for step in range(3):
+                if verbose:
+                    info(f"\t=> Clicking next (step {step + 1}/3)...")
+                self._wait_and_click(By.ID, YOUTUBE_NEXT_BUTTON_ID)
+                time.sleep(1)
 
             # Set as unlisted
             if verbose:
                 info("\t=> Setting as unlisted...")
-
-            radio_button = driver.find_elements(By.XPATH, YOUTUBE_RADIO_BUTTON_XPATH)
-            radio_button[2].click()
+            time.sleep(1)
+            radio_buttons = driver.find_elements(By.XPATH, YOUTUBE_RADIO_BUTTON_XPATH)
+            radio_buttons[2].click()
 
             if verbose:
                 info("\t=> Clicking done button...")
+            self._wait_and_click(By.ID, YOUTUBE_DONE_BUTTON_ID)
 
-            # Click done button
-            done_button = driver.find_element(By.ID, YOUTUBE_DONE_BUTTON_ID)
-            done_button.click()
-
-            # Wait for 2 seconds
-            time.sleep(2)
+            # Wait for processing
+            time.sleep(3)
 
             # Get latest video
             if verbose:
                 info("\t=> Getting video URL...")
 
-            # Get the latest uploaded video URL
             driver.get(
                 f"https://studio.youtube.com/channel/{self.channel_id}/videos/short"
             )
-            time.sleep(2)
+
+            # Wait for video rows to appear
+            self._wait_and_find(By.TAG_NAME, "ytcp-video-row", timeout=30)
+            time.sleep(1)
+
             videos = driver.find_elements(By.TAG_NAME, "ytcp-video-row")
             first_video = videos[0]
             anchor_tag = first_video.find_element(By.TAG_NAME, "a")
@@ -826,9 +831,7 @@ class YouTube:
                 info(f"\t=> Extracting video ID from URL: {href}")
             video_id = href.split("/")[-2]
 
-            # Build URL
             url = build_url(video_id)
-
             self.uploaded_video_url = url
 
             if verbose:
@@ -844,12 +847,16 @@ class YouTube:
                 }
             )
 
-            # Close the browser
             driver.quit()
-
             return True
-        except:
-            self.browser.quit()
+
+        except Exception as e:
+            error(f"Video upload failed: {e}")
+            self._save_screenshot("upload_failure")
+            try:
+                self.browser.quit()
+            except Exception:
+                pass
             return False
 
     def get_videos(self) -> List[dict]:

--- a/src/classes/YouTube.py
+++ b/src/classes/YouTube.py
@@ -743,7 +743,7 @@ class YouTube:
             # Go to youtube.com/upload
             driver.get("https://www.youtube.com/upload")
 
-            # Set video file -- wait for the file picker to appear
+            # Set video file - wait for the file picker to appear
             if verbose:
                 info("\t=> Waiting for file picker...")
             file_picker = self._wait_and_find(By.TAG_NAME, "ytcp-uploads-file-picker")

--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,106 @@ from termcolor import colored
 
 ROOT_DIR = os.path.dirname(sys.path[0])
 
+# Config schema: (key, required, expected_type, default)
+# required=True means the key MUST exist and be non-empty
+# required=False means the key is optional (has a sensible default)
+_CONFIG_SCHEMA = [
+    ("verbose", True, bool, None),
+    ("firefox_profile", False, str, None),
+    ("headless", True, bool, None),
+    ("threads", True, int, None),
+    ("zip_url", False, str, None),
+    ("is_for_kids", True, bool, None),
+    ("font", True, str, None),
+    ("imagemagick_path", True, str, None),
+    ("twitter_language", True, str, None),
+    ("ollama_base_url", False, str, "http://127.0.0.1:11434"),
+    ("ollama_model", False, str, ""),
+    ("nanobanana2_api_base_url", False, str, None),
+    ("nanobanana2_api_key", False, str, None),
+    ("nanobanana2_model", False, str, None),
+    ("nanobanana2_aspect_ratio", False, str, None),
+    ("google_maps_scraper", False, str, None),
+    ("google_maps_scraper_niche", False, str, None),
+    ("scraper_timeout", False, int, 300),
+    ("outreach_message_subject", False, str, None),
+    ("outreach_message_body_file", False, str, None),
+    ("stt_provider", False, str, "local_whisper"),
+    ("whisper_model", False, str, "base"),
+    ("whisper_device", False, str, "auto"),
+    ("whisper_compute_type", False, str, "int8"),
+    ("assembly_ai_api_key", False, str, None),
+    ("tts_voice", False, str, "Jasper"),
+    ("script_sentence_length", False, int, 4),
+    ("email", True, dict, None),
+]
+
+
+def validate_config(config: dict = None) -> list:
+    """
+    Validates the config dictionary against the expected schema.
+    Returns a list of warning/error strings. Empty list means all OK.
+
+    Args:
+        config: Config dict to validate. If None, reads from config.json.
+
+    Returns:
+        issues (list[str]): List of validation issues found.
+    """
+    if config is None:
+        config_path = os.path.join(ROOT_DIR, "config.json")
+        if not os.path.exists(config_path):
+            return [f"config.json not found at {config_path}. Copy config.example.json and fill in values."]
+        with open(config_path, "r") as f:
+            config = json.load(f)
+
+    issues = []
+
+    for key, required, expected_type, default in _CONFIG_SCHEMA:
+        if key not in config:
+            if required:
+                issues.append(f"Missing required key: '{key}'")
+            continue
+
+        value = config[key]
+
+        # Type check (allow None for optional fields)
+        if value is not None and not isinstance(value, expected_type):
+            issues.append(
+                f"Key '{key}' has wrong type: expected {expected_type.__name__}, "
+                f"got {type(value).__name__}"
+            )
+
+        # Empty check for required string fields
+        if required and expected_type == str and (value is None or value == ""):
+            issues.append(f"Required key '{key}' is empty")
+
+    # Validate email sub-structure
+    if "email" in config and isinstance(config["email"], dict):
+        email = config["email"]
+        for email_key in ("smtp_server", "smtp_port", "username", "password"):
+            if email_key not in email:
+                issues.append(f"Missing email sub-key: 'email.{email_key}'")
+
+    # Validate imagemagick_path exists on disk (if set)
+    img_path = config.get("imagemagick_path", "")
+    if img_path and not os.path.exists(img_path):
+        issues.append(
+            f"imagemagick_path '{img_path}' does not exist on disk. "
+            "Video subtitle rendering will fail."
+        )
+
+    # Validate stt_provider is a known value
+    stt = config.get("stt_provider", "local_whisper")
+    if stt not in ("local_whisper", "third_party_assemblyai"):
+        issues.append(
+            f"Unknown stt_provider '{stt}'. "
+            "Expected 'local_whisper' or 'third_party_assemblyai'."
+        )
+
+    return issues
+
+
 def assert_folder_structure() -> None:
     """
     Make sure that the nessecary folder structure is present.

--- a/src/main.py
+++ b/src/main.py
@@ -453,7 +453,7 @@ if __name__ == "__main__":
     # Fetch MP3 Files
     fetch_songs()
 
-    # Select Ollama model — use config value if set, otherwise pick interactively
+    # Select Ollama model - use config value if set, otherwise pick interactively
     configured_model = get_ollama_model()
     if configured_model:
         select_model(configured_model)

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from prettytable import PrettyTable
 from classes.Outreach import Outreach
 from classes.AFM import AffiliateMarketing
 from llm_provider import list_models, select_model, get_active_model
+from config import validate_config
 
 def main():
     """Main entry point for the application, providing a menu-driven interface
@@ -434,6 +435,14 @@ if __name__ == "__main__":
 
     if first_time:
         print(colored("Hey! It looks like you're running MoneyPrinter V2 for the first time. Let's get you setup first!", "yellow"))
+
+    # Validate config
+    config_issues = validate_config()
+    if config_issues:
+        warning("Configuration issues detected:")
+        for issue in config_issues:
+            warning(f"  - {issue}")
+        print()
 
     # Setup file tree
     assert_folder_structure()

--- a/src/status.py
+++ b/src/status.py
@@ -1,71 +1,85 @@
+import os
+import sys
+import logging
+from logging.handlers import RotatingFileHandler
+
 from termcolor import colored
 
+# Project root used for log file placement
+_ROOT_DIR = os.path.dirname(sys.path[0])
+_LOG_DIR = os.path.join(_ROOT_DIR, ".mp")
+
+_logger = logging.getLogger("mpv2")
+_logger.setLevel(logging.DEBUG)
+
+# Prevent duplicate handlers when the module is re-imported
+if not _logger.handlers:
+    # Console handler -- always INFO+ with color handled by the functions below
+    _console_handler = logging.StreamHandler(sys.stdout)
+    _console_handler.setLevel(logging.DEBUG)
+    _console_handler.setFormatter(logging.Formatter("%(message)s"))
+    _logger.addHandler(_console_handler)
+
+    # File handler -- rotates at 5 MB, keeps 3 backups
+    try:
+        os.makedirs(_LOG_DIR, exist_ok=True)
+        _file_handler = RotatingFileHandler(
+            os.path.join(_LOG_DIR, "mpv2.log"),
+            maxBytes=5 * 1024 * 1024,
+            backupCount=3,
+            encoding="utf-8",
+        )
+        _file_handler.setLevel(logging.DEBUG)
+        _file_handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        )
+        _logger.addHandler(_file_handler)
+    except OSError:
+        # .mp dir might not exist yet on very first run; file logging will
+        # start working after assert_folder_structure() runs.
+        pass
+
+
 def error(message: str, show_emoji: bool = True) -> None:
-    """
-    Prints an error message.
+    """Prints an error message and logs it at ERROR level."""
+    emoji = "X" if show_emoji else ""
+    _logger.error(f"{emoji} {message}" if emoji else message)
+    # Also print colored to console for backwards compat
+    print(colored(f"{emoji} {message}", "red"), file=sys.stderr)
 
-    Args:
-        message (str): The error message
-        show_emoji (bool): Whether to show the emoji
-
-    Returns:
-        None
-    """
-    emoji = "❌" if show_emoji else ""
-    print(colored(f"{emoji} {message}", "red"))
 
 def success(message: str, show_emoji: bool = True) -> None:
-    """
-    Prints a success message.
+    """Prints a success message and logs it at INFO level."""
+    emoji = "+" if show_emoji else ""
+    display = f"[{emoji}] {message}" if emoji else message
+    _logger.info(display)
+    print(colored(display, "green"))
 
-    Args:
-        message (str): The success message
-        show_emoji (bool): Whether to show the emoji
-
-    Returns:
-        None
-    """
-    emoji = "✅" if show_emoji else ""
-    print(colored(f"{emoji} {message}", "green"))
 
 def info(message: str, show_emoji: bool = True) -> None:
-    """
-    Prints an info message.
+    """Prints an info message and logs it at INFO level."""
+    emoji = "[i]" if show_emoji else ""
+    display = f"{emoji} {message}" if emoji else message
+    _logger.info(display)
+    print(colored(display, "magenta"))
 
-    Args:
-        message (str): The info message
-        show_emoji (bool): Whether to show the emoji
-
-    Returns:
-        None
-    """
-    emoji = "ℹ️" if show_emoji else ""
-    print(colored(f"{emoji} {message}", "magenta"))
 
 def warning(message: str, show_emoji: bool = True) -> None:
-    """
-    Prints a warning message.
+    """Prints a warning message and logs it at WARNING level."""
+    emoji = "[!]" if show_emoji else ""
+    display = f"{emoji} {message}" if emoji else message
+    _logger.warning(display)
+    print(colored(display, "yellow"))
 
-    Args:
-        message (str): The warning message
-        show_emoji (bool): Whether to show the emoji
-
-    Returns:
-        None
-    """
-    emoji = "⚠️" if show_emoji else ""
-    print(colored(f"{emoji} {message}", "yellow"))
 
 def question(message: str, show_emoji: bool = True) -> str:
-    """
-    Prints a question message and returns the user's input.
+    """Prints a question message and returns the user's input."""
+    emoji = "[?]" if show_emoji else ""
+    display = f"{emoji} {message}" if emoji else message
+    _logger.info(f"PROMPT: {display}")
+    return input(colored(display, "magenta"))
 
-    Args:
-        message (str): The question message
-        show_emoji (bool): Whether to show the emoji
 
-    Returns:
-        user_input (str): The user's input
-    """
-    emoji = "❓" if show_emoji else ""
-    return input(colored(f"{emoji} {message}", "magenta"))
+def get_logger() -> logging.Logger:
+    """Returns the application logger for direct use in modules that need it."""
+    return _logger

--- a/src/status.py
+++ b/src/status.py
@@ -14,13 +14,13 @@ _logger.setLevel(logging.DEBUG)
 
 # Prevent duplicate handlers when the module is re-imported
 if not _logger.handlers:
-    # Console handler -- always INFO+ with color handled by the functions below
+    # Console handler - always INFO+ with color handled by the functions below
     _console_handler = logging.StreamHandler(sys.stdout)
     _console_handler.setLevel(logging.DEBUG)
     _console_handler.setFormatter(logging.Formatter("%(message)s"))
     _logger.addHandler(_console_handler)
 
-    # File handler -- rotates at 5 MB, keeps 3 backups
+    # File handler - rotates at 5 MB, keeps 3 backups
     try:
         os.makedirs(_LOG_DIR, exist_ok=True)
         _file_handler = RotatingFileHandler(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,64 @@
+import os
+import json
+import pytest
+
+
+@pytest.fixture
+def tmp_project(tmp_path):
+    """
+    Creates a minimal project structure that mirrors MoneyPrinterV2 layout.
+    Returns the project root directory.
+    """
+    mp_dir = tmp_path / ".mp"
+    mp_dir.mkdir()
+
+    config = {
+        "verbose": False,
+        "firefox_profile": "",
+        "headless": True,
+        "ollama_base_url": "http://127.0.0.1:11434",
+        "ollama_model": "test-model",
+        "twitter_language": "English",
+        "nanobanana2_api_base_url": "https://generativelanguage.googleapis.com/v1beta",
+        "nanobanana2_api_key": "test-key",
+        "nanobanana2_model": "gemini-3.1-flash-image-preview",
+        "nanobanana2_aspect_ratio": "9:16",
+        "threads": 2,
+        "zip_url": "",
+        "is_for_kids": False,
+        "google_maps_scraper": "",
+        "email": {
+            "smtp_server": "smtp.gmail.com",
+            "smtp_port": 587,
+            "username": "test@test.com",
+            "password": "password",
+        },
+        "google_maps_scraper_niche": "restaurants",
+        "scraper_timeout": 300,
+        "outreach_message_subject": "Hello {{COMPANY_NAME}}",
+        "outreach_message_body_file": "outreach.html",
+        "stt_provider": "local_whisper",
+        "whisper_model": "base",
+        "whisper_device": "auto",
+        "whisper_compute_type": "int8",
+        "assembly_ai_api_key": "test-key",
+        "tts_voice": "Jasper",
+        "font": "bold_font.ttf",
+        "imagemagick_path": "/usr/bin/convert",
+        "script_sentence_length": 4,
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    return tmp_path
+
+
+@pytest.fixture
+def patch_root_dir(tmp_project, monkeypatch):
+    """
+    Patches ROOT_DIR in config module to point to our tmp project.
+    """
+    import config
+
+    monkeypatch.setattr(config, "ROOT_DIR", str(tmp_project))
+    yield tmp_project

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,140 @@
+import json
+import os
+
+import pytest
+
+import cache
+import config
+
+
+@pytest.fixture
+def cache_env(patch_root_dir):
+    """Sets up cache directory and patches ROOT_DIR in cache module too."""
+    import cache as cache_mod
+
+    original = cache_mod.ROOT_DIR
+    cache_mod.ROOT_DIR = str(patch_root_dir)
+    yield patch_root_dir
+    cache_mod.ROOT_DIR = original
+
+
+class TestCachePaths:
+    def test_get_cache_path(self, cache_env):
+        path = cache.get_cache_path()
+        assert path.endswith(".mp")
+
+    def test_get_twitter_cache_path(self, cache_env):
+        assert cache.get_twitter_cache_path().endswith("twitter.json")
+
+    def test_get_youtube_cache_path(self, cache_env):
+        assert cache.get_youtube_cache_path().endswith("youtube.json")
+
+    def test_get_afm_cache_path(self, cache_env):
+        assert cache.get_afm_cache_path().endswith("afm.json")
+
+
+class TestProviderCachePath:
+    def test_twitter_provider(self, cache_env):
+        assert cache.get_provider_cache_path("twitter") == cache.get_twitter_cache_path()
+
+    def test_youtube_provider(self, cache_env):
+        assert cache.get_provider_cache_path("youtube") == cache.get_youtube_cache_path()
+
+    def test_invalid_provider_raises(self, cache_env):
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            cache.get_provider_cache_path("instagram")
+
+
+class TestAccounts:
+    def test_get_accounts_creates_file_when_missing(self, cache_env):
+        accounts = cache.get_accounts("twitter")
+        assert accounts == []
+        assert os.path.exists(cache.get_twitter_cache_path())
+
+    def test_add_account(self, cache_env):
+        account = {"id": "abc-123", "nickname": "test", "posts": []}
+        cache.add_account("twitter", account)
+        accounts = cache.get_accounts("twitter")
+        assert len(accounts) == 1
+        assert accounts[0]["id"] == "abc-123"
+
+    def test_add_multiple_accounts(self, cache_env):
+        cache.add_account("youtube", {"id": "yt-1", "nickname": "a", "videos": []})
+        cache.add_account("youtube", {"id": "yt-2", "nickname": "b", "videos": []})
+        accounts = cache.get_accounts("youtube")
+        assert len(accounts) == 2
+
+    def test_remove_account(self, cache_env):
+        cache.add_account("twitter", {"id": "del-me", "nickname": "gone", "posts": []})
+        cache.add_account("twitter", {"id": "keep-me", "nickname": "stay", "posts": []})
+        cache.remove_account("twitter", "del-me")
+        accounts = cache.get_accounts("twitter")
+        assert len(accounts) == 1
+        assert accounts[0]["id"] == "keep-me"
+
+    def test_remove_nonexistent_account(self, cache_env):
+        cache.add_account("twitter", {"id": "only", "nickname": "one", "posts": []})
+        cache.remove_account("twitter", "does-not-exist")
+        accounts = cache.get_accounts("twitter")
+        assert len(accounts) == 1
+
+
+class TestAtomicWrites:
+    def test_atomic_write_creates_valid_json(self, cache_env):
+        """Verify _write_json_atomic produces valid JSON."""
+        test_path = os.path.join(str(cache_env), ".mp", "test_atomic.json")
+        data = {"key": "value", "nested": {"a": 1}}
+        cache._write_json_atomic(test_path, data)
+
+        with open(test_path, "r") as f:
+            loaded = json.load(f)
+        assert loaded == data
+
+    def test_atomic_write_no_partial_on_error(self, cache_env):
+        """If serialization fails, original file should remain untouched."""
+        test_path = os.path.join(str(cache_env), ".mp", "test_safe.json")
+        original_data = {"original": True}
+        cache._write_json_atomic(test_path, original_data)
+
+        # Try to write non-serializable data
+        class BadObj:
+            pass
+
+        try:
+            cache._write_json_atomic(test_path, {"bad": BadObj()})
+        except TypeError:
+            pass
+
+        # Original should still be intact
+        with open(test_path, "r") as f:
+            loaded = json.load(f)
+        assert loaded == original_data
+
+    def test_locked_read(self, cache_env):
+        """Verify _read_json_locked reads correctly."""
+        test_path = os.path.join(str(cache_env), ".mp", "test_read.json")
+        data = {"accounts": [{"id": "test"}]}
+        cache._write_json_atomic(test_path, data)
+
+        result = cache._read_json_locked(test_path)
+        assert result == data
+
+
+class TestProducts:
+    def test_get_products_creates_file_when_missing(self, cache_env):
+        products = cache.get_products()
+        assert products == []
+        assert os.path.exists(cache.get_afm_cache_path())
+
+    def test_add_product(self, cache_env):
+        product = {"id": "prod-1", "affiliate_link": "https://amzn.to/abc", "twitter_uuid": "tw-1"}
+        cache.add_product(product)
+        products = cache.get_products()
+        assert len(products) == 1
+        assert products[0]["id"] == "prod-1"
+
+    def test_add_multiple_products(self, cache_env):
+        cache.add_product({"id": "p1", "affiliate_link": "https://a.co/1", "twitter_uuid": "t1"})
+        cache.add_product({"id": "p2", "affiliate_link": "https://a.co/2", "twitter_uuid": "t2"})
+        products = cache.get_products()
+        assert len(products) == 2

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,107 @@
+import json
+import os
+
+import config
+
+
+class TestValidateConfig:
+    def test_valid_config_no_issues(self, patch_root_dir):
+        issues = config.validate_config()
+        # imagemagick_path won't exist in tmp, so filter that out
+        non_path_issues = [i for i in issues if "imagemagick_path" not in i]
+        assert non_path_issues == []
+
+    def test_missing_required_key(self):
+        cfg = {"headless": True}
+        issues = config.validate_config(cfg)
+        missing = [i for i in issues if "Missing required key" in i]
+        assert len(missing) > 0
+
+    def test_wrong_type(self):
+        cfg = {
+            "verbose": "yes",  # should be bool
+            "headless": True,
+            "threads": 2,
+            "is_for_kids": False,
+            "font": "bold.ttf",
+            "imagemagick_path": "/usr/bin/convert",
+            "twitter_language": "English",
+            "email": {"smtp_server": "s", "smtp_port": 587, "username": "u", "password": "p"},
+            "zip_url": "",
+        }
+        issues = config.validate_config(cfg)
+        type_issues = [i for i in issues if "wrong type" in i]
+        assert any("verbose" in i for i in type_issues)
+
+    def test_missing_email_subkeys(self):
+        cfg = {
+            "verbose": True,
+            "headless": True,
+            "threads": 2,
+            "is_for_kids": False,
+            "font": "bold.ttf",
+            "imagemagick_path": "/usr/bin/convert",
+            "twitter_language": "English",
+            "email": {"smtp_server": "s"},
+            "zip_url": "",
+        }
+        issues = config.validate_config(cfg)
+        email_issues = [i for i in issues if "email." in i]
+        assert len(email_issues) == 3  # missing smtp_port, username, password
+
+    def test_invalid_stt_provider(self):
+        cfg = {
+            "verbose": True,
+            "headless": True,
+            "threads": 2,
+            "is_for_kids": False,
+            "font": "bold.ttf",
+            "imagemagick_path": "/usr/bin/convert",
+            "twitter_language": "English",
+            "email": {"smtp_server": "s", "smtp_port": 587, "username": "u", "password": "p"},
+            "stt_provider": "google_cloud",
+            "zip_url": "",
+        }
+        issues = config.validate_config(cfg)
+        stt_issues = [i for i in issues if "stt_provider" in i]
+        assert len(stt_issues) == 1
+
+    def test_imagemagick_path_missing_on_disk(self):
+        cfg = {
+            "verbose": True,
+            "headless": True,
+            "threads": 2,
+            "is_for_kids": False,
+            "font": "bold.ttf",
+            "imagemagick_path": "/nonexistent/path/magick",
+            "twitter_language": "English",
+            "email": {"smtp_server": "s", "smtp_port": 587, "username": "u", "password": "p"},
+            "zip_url": "",
+        }
+        issues = config.validate_config(cfg)
+        path_issues = [i for i in issues if "does not exist on disk" in i]
+        assert len(path_issues) == 1
+
+    def test_config_file_not_found(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "ROOT_DIR", str(tmp_path))
+        # No config.json in tmp_path
+        issues = config.validate_config()
+        assert any("not found" in i for i in issues)
+
+    def test_valid_stt_providers_accepted(self):
+        for provider in ("local_whisper", "third_party_assemblyai"):
+            cfg = {
+                "verbose": True,
+                "headless": True,
+                "threads": 2,
+                "is_for_kids": False,
+                "font": "bold.ttf",
+                "imagemagick_path": "/usr/bin/convert",
+                "twitter_language": "English",
+                "email": {"smtp_server": "s", "smtp_port": 587, "username": "u", "password": "p"},
+                "stt_provider": provider,
+                "zip_url": "",
+            }
+            issues = config.validate_config(cfg)
+            stt_issues = [i for i in issues if "stt_provider" in i]
+            assert len(stt_issues) == 0

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,39 @@
+import os
+import logging
+
+import status
+
+
+class TestLogging:
+    def test_get_logger_returns_logger(self):
+        logger = status.get_logger()
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == "mpv2"
+
+    def test_logger_has_handlers(self):
+        logger = status.get_logger()
+        assert len(logger.handlers) > 0
+
+    def test_error_logs_to_logger(self, capfd):
+        status.error("test error message", show_emoji=False)
+        captured = capfd.readouterr()
+        assert "test error message" in captured.err
+
+    def test_success_prints_message(self, capfd):
+        status.success("test success", show_emoji=False)
+        captured = capfd.readouterr()
+        assert "test success" in captured.out
+
+    def test_info_prints_message(self, capfd):
+        status.info("test info", show_emoji=False)
+        captured = capfd.readouterr()
+        assert "test info" in captured.out
+
+    def test_warning_prints_message(self, capfd):
+        status.warning("test warning", show_emoji=False)
+        captured = capfd.readouterr()
+        assert "test warning" in captured.out
+
+    def test_logger_level_is_debug(self):
+        logger = status.get_logger()
+        assert logger.level == logging.DEBUG


### PR DESCRIPTION
## Summary

- **Structured logging**: Replace `status.py` print/termcolor output with Python's `logging` module. Logs rotate at 5MB with 3 backups in `.mp/mpv2.log`. Console output remains colored for backwards compatibility. Exposes `get_logger()` for modules that need direct logger access.
- **Config validation**: New `validate_config()` function with schema-based checking -- verifies required keys exist, types match, email sub-structure is complete, `imagemagick_path` exists on disk, and `stt_provider` is a known value. Runs automatically at startup in `main.py` and prints all issues as warnings so users can fix their config before hitting cryptic errors later.
- **Thread-safe cache**: All JSON cache reads now use `fcntl.LOCK_SH` (shared locks), all writes use atomic temp-file + `os.replace()` with `fcntl.LOCK_EX` (exclusive locks). This prevents cache corruption when multiple CRON jobs run concurrently against the same `.mp/*.json` files.
- **Selenium improvements**: Replace hardcoded `time.sleep()` waits in YouTube `upload_video()` with `WebDriverWait` + explicit `expected_conditions` (presence/clickability). Adds automatic screenshot capture on upload failure for debugging. Adds helper methods `_wait_and_find()` and `_wait_and_click()`.
- **Cleanup**: Replace stray `print(colored(...))` calls in `YouTube.py` and `Outreach.py` with proper `info()`/`error()`/`success()` functions.
- **Tests**: 33 new tests covering config validation, atomic cache writes, file locking, and structured logging.

## Test plan

- [x] All 33 tests pass locally (`python -m pytest tests/ -v`)
- [ ] Manual smoke test of `python src/main.py` to verify config validation prints warnings for missing/invalid values
- [ ] Verify `.mp/mpv2.log` is created after first run