### PR TITLE
fix(llm_provider): wrap Ollama calls with descriptive error messages

### DIFF
--- a/src/llm_provider.py
+++ b/src/llm_provider.py
@@ -55,9 +55,15 @@ def generate_text(prompt: str, model_name: str = None) -> str:
             "No Ollama model selected. Call select_model() first or pass model_name."
         )
 
-    response = _client().chat(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-    )
+    try:
+        response = _client().chat(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Ollama request failed (model={model}): {e}. "
+            "Ensure the Ollama server is running and the model is pulled."
+        ) from e
 
     return response["message"]["content"].strip()


### PR DESCRIPTION
## Summary
- Wrap Ollama chat() call with try/except providing clear error message
- Helps users diagnose server connectivity and model availability issues

Closes #232

## Test plan
- [ ] Verify text generation works with running Ollama server
- [ ] Stop Ollama and verify descriptive error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)