### PR TITLE
fix(cron): fail fast when account UUID is missing

### DIFF
--- a/src/cron.py
+++ b/src/cron.py
@@ -45,21 +45,24 @@ def main():
 
         if not account_id:
             error("Account UUID cannot be empty.")
+            sys.exit(1)
 
-        for acc in accounts:
-            if acc["id"] == account_id:
-                if verbose:
-                    info("Initializing Twitter...")
-                twitter = Twitter(
-                    acc["id"],
-                    acc["nickname"],
-                    acc["firefox_profile"],
-                    acc["topic"]
-                )
-                twitter.post()
-                if verbose:
-                    success("Done posting.")
-                break
+        account = next((acc for acc in accounts if acc.get("id") == account_id), None)
+        if account is None:
+            error(f'Twitter account UUID "{account_id}" was not found in cache.')
+            sys.exit(1)
+
+        if verbose:
+            info("Initializing Twitter...")
+        twitter = Twitter(
+            account["id"],
+            account["nickname"],
+            account["firefox_profile"],
+            account["topic"]
+        )
+        twitter.post()
+        if verbose:
+            success("Done posting.")
     elif purpose == "youtube":
         tts = TTS()
 
@@ -67,31 +70,34 @@ def main():
 
         if not account_id:
             error("Account UUID cannot be empty.")
+            sys.exit(1)
 
-        for acc in accounts:
-            if acc["id"] == account_id:
-                if verbose:
-                    info("Initializing YouTube...")
-                youtube = YouTube(
-                    acc["id"],
-                    acc["nickname"],
-                    acc["firefox_profile"],
-                    acc["niche"],
-                    acc["language"]
-                )
-                youtube.generate_video(tts)
-                upload_success = youtube.upload_video()
-                if upload_success:
-                    if verbose:
-                        success("Uploaded Short.")
-                    maybe_crosspost_youtube_short(
-                        video_path=youtube.video_path,
-                        title=youtube.metadata.get("title", ""),
-                        interactive=False,
-                    )
-                else:
-                    warning("YouTube upload failed. Skipping Post Bridge cross-post.")
-                break
+        account = next((acc for acc in accounts if acc.get("id") == account_id), None)
+        if account is None:
+            error(f'YouTube account UUID "{account_id}" was not found in cache.')
+            sys.exit(1)
+
+        if verbose:
+            info("Initializing YouTube...")
+        youtube = YouTube(
+            account["id"],
+            account["nickname"],
+            account["firefox_profile"],
+            account["niche"],
+            account["language"]
+        )
+        youtube.generate_video(tts)
+        upload_success = youtube.upload_video()
+        if upload_success:
+            if verbose:
+                success("Uploaded Short.")
+            maybe_crosspost_youtube_short(
+                video_path=youtube.video_path,
+                title=youtube.metadata.get("title", ""),
+                interactive=False,
+            )
+        else:
+            warning("YouTube upload failed. Skipping Post Bridge cross-post.")
     else:
         error("Invalid Purpose, exiting...")
         sys.exit(1)

--- a/tests/test_cron_post_bridge.py
+++ b/tests/test_cron_post_bridge.py
@@ -20,6 +20,27 @@ fake_ollama = types.ModuleType("ollama")
 fake_ollama.Client = object
 sys.modules.setdefault("ollama", fake_ollama)
 
+fake_termcolor = types.ModuleType("termcolor")
+fake_termcolor.colored = lambda text, *_args, **_kwargs: text
+sys.modules.setdefault("termcolor", fake_termcolor)
+
+fake_status = types.ModuleType("status")
+fake_status.info = lambda *args, **kwargs: None
+fake_status.success = lambda *args, **kwargs: None
+fake_status.warning = lambda *args, **kwargs: None
+fake_status.error = lambda *args, **kwargs: None
+fake_status.question = lambda *_args, **_kwargs: ""
+sys.modules.setdefault("status", fake_status)
+
+fake_cache = types.ModuleType("cache")
+fake_cache.get_accounts = lambda _provider: []
+sys.modules.setdefault("cache", fake_cache)
+
+fake_config = types.ModuleType("config")
+fake_config.get_verbose = lambda: False
+fake_config.get_post_bridge_config = lambda: {}
+sys.modules.setdefault("config", fake_config)
+
 fake_llm_provider = types.ModuleType("llm_provider")
 fake_llm_provider.select_model = lambda model: None
 sys.modules.setdefault("llm_provider", fake_llm_provider)
@@ -82,6 +103,67 @@ class CronPostBridgeTests(unittest.TestCase):
         youtube_instance.generate_video.assert_called_once()
         youtube_instance.upload_video.assert_called_once()
         crosspost_mock.assert_not_called()
+
+    @patch("cron.Twitter")
+    @patch("cron.get_accounts")
+    @patch("cron.select_model")
+    @patch("cron.get_verbose")
+    @patch("cron.error")
+    def test_twitter_missing_account_id_exits_with_error(
+        self,
+        error_mock,
+        get_verbose_mock,
+        select_model_mock,
+        get_accounts_mock,
+        twitter_cls_mock,
+    ) -> None:
+        get_verbose_mock.return_value = False
+        get_accounts_mock.return_value = [{"id": "twitter-1"}]
+
+        with patch.object(
+            sys,
+            "argv",
+            ["cron.py", "twitter", "missing-id", "llama3.2:3b"],
+        ), patch("cron.sys.exit", side_effect=SystemExit(1)) as exit_mock:
+            with self.assertRaises(SystemExit):
+                cron.main()
+
+        select_model_mock.assert_called_once_with("llama3.2:3b")
+        error_mock.assert_called_once_with('Twitter account UUID "missing-id" was not found in cache.')
+        exit_mock.assert_called_once_with(1)
+        twitter_cls_mock.assert_not_called()
+
+    @patch("cron.YouTube")
+    @patch("cron.TTS")
+    @patch("cron.get_accounts")
+    @patch("cron.select_model")
+    @patch("cron.get_verbose")
+    @patch("cron.error")
+    def test_youtube_missing_account_id_exits_with_error(
+        self,
+        error_mock,
+        get_verbose_mock,
+        select_model_mock,
+        get_accounts_mock,
+        tts_cls_mock,
+        youtube_cls_mock,
+    ) -> None:
+        get_verbose_mock.return_value = False
+        get_accounts_mock.return_value = [{"id": "youtube-1"}]
+
+        with patch.object(
+            sys,
+            "argv",
+            ["cron.py", "youtube", "missing-id", "llama3.2:3b"],
+        ), patch("cron.sys.exit", side_effect=SystemExit(1)) as exit_mock:
+            with self.assertRaises(SystemExit):
+                cron.main()
+
+        select_model_mock.assert_called_once_with("llama3.2:3b")
+        error_mock.assert_called_once_with('YouTube account UUID "missing-id" was not found in cache.')
+        exit_mock.assert_called_once_with(1)
+        tts_cls_mock.assert_called_once()
+        youtube_cls_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `cron.py` exit with code 1 when the provided account UUID is empty or not found in cache
- avoid silent no-op runs for both `twitter` and `youtube` cron paths
- add regression tests for missing-account behavior

## Validation
- `pytest tests/test_cron_post_bridge.py`

Closes #229