### PR TITLE
fix(Outreach): clear stale scraper cache before each run

### DIFF
--- a/src/classes/Outreach.py
+++ b/src/classes/Outreach.py
@@ -222,6 +222,9 @@ class Outreach:
         message_subject = get_outreach_message_subject()
         message_body = get_outreach_message_body_file()
 
+        if os.path.exists(output_path):
+            os.remove(output_path)
+
         # Run
         self.run_scraper_with_args_for_30_seconds(
             f'-input niche.txt -results "{output_path}"', timeout=get_scraper_timeout()

--- a/tests/test_outreach_stale_results.py
+++ b/tests/test_outreach_stale_results.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+SRC_DIR = os.path.join(ROOT_DIR, "src")
+
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+sys.modules.setdefault("srt_equalizer", types.SimpleNamespace())
+sys.modules.setdefault("yagmail", types.SimpleNamespace(SMTP=lambda **kwargs: None))
+sys.modules.setdefault("requests", types.SimpleNamespace(get=lambda *args, **kwargs: None))
+sys.modules.setdefault("termcolor", types.SimpleNamespace(colored=lambda text, *_args, **_kwargs: text))
+
+from classes.Outreach import Outreach
+
+
+class OutreachStaleResultsTests(unittest.TestCase):
+    def test_start_removes_stale_results_before_running_scraper(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stale_output_path = os.path.join(temp_dir, "scraper_results.csv")
+            niche_path = os.path.join(temp_dir, "niche.txt")
+
+            with open(stale_output_path, "w", encoding="utf-8") as handle:
+                handle.write("company,website\nOld Lead,https://old.example\n")
+
+            outreach = Outreach.__new__(Outreach)
+            outreach.niche = "plumbers in hanoi"
+            outreach.email_creds = {
+                "username": "user@example.com",
+                "password": "secret",
+                "smtp_server": "smtp.example.com",
+                "smtp_port": 587,
+            }
+
+            run_calls = []
+            error_messages = []
+
+            def fake_run(args: str, timeout: int) -> None:
+                run_calls.append((args, timeout))
+                self.assertFalse(
+                    os.path.exists(stale_output_path),
+                    "stale scraper output should be deleted before the scraper runs",
+                )
+
+            with patch("classes.Outreach.get_results_cache_path", return_value=stale_output_path), \
+                patch("classes.Outreach.get_google_maps_scraper_zip_url", return_value="https://example.com/scraper.zip"), \
+                patch("classes.Outreach.get_outreach_message_subject", return_value="Hello {{COMPANY_NAME}}"), \
+                patch("classes.Outreach.get_outreach_message_body_file", return_value=os.path.join(temp_dir, "body.txt")), \
+                patch("classes.Outreach.get_scraper_timeout", return_value=30), \
+                patch.object(outreach, "is_go_installed", return_value=True), \
+                patch.object(outreach, "unzip_file"), \
+                patch.object(outreach, "build_scraper"), \
+                patch.object(outreach, "run_scraper_with_args_for_30_seconds", side_effect=fake_run), \
+                patch("classes.Outreach.error", side_effect=error_messages.append), \
+                patch("classes.Outreach.requests.get"):
+                cwd = os.getcwd()
+                try:
+                    os.chdir(temp_dir)
+                    outreach.start()
+                finally:
+                    os.chdir(cwd)
+
+            self.assertEqual(len(run_calls), 1)
+            self.assertFalse(os.path.exists(stale_output_path))
+            self.assertFalse(os.path.exists(niche_path))
+            self.assertEqual(
+                error_messages,
+                [
+                    f" => Scraper output not found at {stale_output_path}. Check scraper logs and configuration."
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix(Outreach): clear stale scraper cache before each run

## Reproduction

The outreach flow uses a fixed output path for scraper results: `.mp/scraper_results.csv`.
If that file exists from an earlier successful run and the current scraper run fails or times out before writing fresh output, `Outreach.start()` still finds the file and proceeds with stale data.

## Analysis

`src/cache.py` returns a stable cache path, and `src/classes/Outreach.py` only checked `os.path.exists(output_path)` after the scraper command completed. There was no freshness check and no cleanup of previous output before the new run.

## Patch Summary

- delete any existing scraper results cache file before launching the scraper
- add a focused unit test covering stale-cache reuse across runs

## Risks

Low risk. The behavior change is limited to the outreach scraper output cache and only affects the start of a new outreach run.

## Test Coverage

```bash
python3 -m unittest tests.test_outreach_stale_results
```
