### PR TITLE
fix(Outreach): delete stale scraper_results.csv before each run

### DIFF
--- a/src/classes/Outreach.py
+++ b/src/classes/Outreach.py
@@ -222,6 +222,11 @@ class Outreach:
         message_subject = get_outreach_message_subject()
         message_body = get_outreach_message_body_file()
 
+        # Remove any stale results file from a previous run so we can reliably
+        # detect whether the current scraper invocation produced fresh output.
+        if os.path.exists(output_path):
+            os.remove(output_path)
+
         # Run
         self.run_scraper_with_args_for_30_seconds(
             f'-input niche.txt -results "{output_path}"', timeout=get_scraper_timeout()


### PR DESCRIPTION
Fixes #256

## Problem

`Outreach.start()` runs the scraper and then checks `os.path.exists(output_path)` to determine if scraping succeeded. However, `.mp/scraper_results.csv` always points to a fixed path (`get_results_cache_path()`). If the file already exists from a previous successful run, this check passes even when the current scraper invocation fails or times out — causing the outreach flow to send emails based on stale lead data.

## Solution

Delete `scraper_results.csv` before invoking the scraper. After the scraper finishes, the existing `os.path.exists()` check is now reliable: the file can only exist if the current run produced it.

## Testing

1. Run Outreach once so `.mp/scraper_results.csv` is created.
2. Cause the next scraper invocation to fail (e.g. kill the process or pass an invalid niche).
3. **Before this fix**: the stale CSV is found and outreach emails are sent to old leads.
4. **After this fix**: the stale CSV is removed before the run; when the scraper fails no new file is written; `os.path.exists()` returns `False` and the error path is taken correctly.