### PR TITLE
fix(config): Preserve explicit zero scraper timeout

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -201,7 +201,8 @@ def get_scraper_timeout() -> int:
         timeout (int): The timeout
     """
     with open(os.path.join(ROOT_DIR, "config.json"), "r") as file:
-        return json.load(file)["scraper_timeout"] or 300
+        timeout = json.load(file).get("scraper_timeout")
+        return 300 if timeout is None else timeout
 
 def get_outreach_message_subject() -> str:
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,24 @@ class PostBridgeConfigTests(unittest.TestCase):
         self.assertEqual(post_bridge_config["account_ids"], [])
         self.assertFalse(post_bridge_config["enabled"])
 
+    def test_scraper_timeout_allows_explicit_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.write_config(temp_dir, {"scraper_timeout": 0})
+
+            with patch.object(config, "ROOT_DIR", temp_dir):
+                timeout = config.get_scraper_timeout()
+
+        self.assertEqual(timeout, 0)
+
+    def test_scraper_timeout_defaults_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.write_config(temp_dir, {})
+
+            with patch.object(config, "ROOT_DIR", temp_dir):
+                timeout = config.get_scraper_timeout()
+
+        self.assertEqual(timeout, 300)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Preserves an explicit `scraper_timeout` value of `0` instead of treating it as missing and replacing it with the default `300`.

The config helper now defaults only when the key is absent or set to `null`, and the regression tests cover both explicit zero and missing-key behavior.

## Verification

- `. .venv/bin/activate && python -m pytest tests/test_config.py -q` (`6 passed`)