### PR TITLE
fix(llm): Wrap Ollama provider errors

### DIFF
--- a/src/llm_provider.py
+++ b/src/llm_provider.py
@@ -16,8 +16,17 @@ def list_models() -> list[str]:
     Returns:
         models (list[str]): Sorted list of model names.
     """
-    response = _client().list()
-    return sorted(m.model for m in response.models)
+    try:
+        response = _client().list()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Unable to list Ollama models from {get_ollama_base_url()}: {exc}"
+        ) from exc
+
+    try:
+        return sorted(m.model for m in response.models)
+    except Exception as exc:
+        raise RuntimeError("Ollama returned an unexpected model list response") from exc
 
 
 def select_model(model: str) -> None:
@@ -55,9 +64,15 @@ def generate_text(prompt: str, model_name: str = None) -> str:
             "No Ollama model selected. Call select_model() first or pass model_name."
         )
 
-    response = _client().chat(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-    )
+    try:
+        response = _client().chat(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception as exc:
+        raise RuntimeError(f"Ollama chat request failed for model '{model}': {exc}") from exc
 
-    return response["message"]["content"].strip()
+    try:
+        return response["message"]["content"].strip()
+    except Exception as exc:
+        raise RuntimeError("Ollama returned an unexpected chat response") from exc

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+SRC_DIR = os.path.join(ROOT_DIR, "src")
+
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+fake_ollama = types.ModuleType("ollama")
+fake_ollama.Client = object
+sys.modules.setdefault("ollama", fake_ollama)
+
+fake_config = types.ModuleType("config")
+fake_config.get_ollama_base_url = lambda: "http://127.0.0.1:11434"
+sys.modules.setdefault("config", fake_config)
+
+import llm_provider
+
+
+class LlmProviderErrorHandlingTests(unittest.TestCase):
+    def test_list_models_wraps_ollama_connection_errors(self) -> None:
+        with patch.object(llm_provider, "_client", side_effect=ConnectionError("down")):
+            with self.assertRaisesRegex(RuntimeError, "Unable to list Ollama models"):
+                llm_provider.list_models()
+
+    def test_generate_text_wraps_ollama_chat_errors(self) -> None:
+        class FailingClient:
+            def chat(self, **kwargs):
+                raise TimeoutError("timed out")
+
+        with patch.object(llm_provider, "_client", return_value=FailingClient()):
+            with self.assertRaisesRegex(RuntimeError, "Ollama chat request failed for model 'llama3'"):
+                llm_provider.generate_text("hello", model_name="llama3")
+
+    def test_generate_text_wraps_malformed_chat_response(self) -> None:
+        class MalformedClient:
+            def chat(self, **kwargs):
+                return {"message": {}}
+
+        with patch.object(llm_provider, "_client", return_value=MalformedClient()):
+            with self.assertRaisesRegex(RuntimeError, "unexpected chat response"):
+                llm_provider.generate_text("hello", model_name="llama3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Wrap Ollama model-list and chat failures in clearer `RuntimeError` messages
- Report malformed Ollama model-list/chat responses as explicit provider errors
- Add focused tests that stub Ollama/config dependencies without requiring a live Ollama server

Fixes #232.

## Verification

- `python3 -m pytest tests/test_llm_provider.py -q`
- `git diff --check`